### PR TITLE
Bug cleanup

### DIFF
--- a/WrightSim/experiment/_experiment.py
+++ b/WrightSim/experiment/_experiment.py
@@ -55,7 +55,7 @@ class Experiment:
     def axis_names(self):
         return [a.name for a in self.axes]
 
-    def run(self, hamiltonian, mp=True):
+    def run(self, hamiltonian, mp=True, windowed=True):
         """Run the experiment.
 
         Parameters
@@ -64,12 +64,13 @@ class Experiment:
             Hamiltonian.
         mp : boolean (optional)
             Toggle CPU multiprocessing. Default is True.
-
+        windowed : boolean (optional)
+            Toggle truncating output bounds.  Default is True.
         Returns
         -------
         WrightSim Scan
             Scan that was run."""
-        out = Scan(self, hamiltonian)
+        out = Scan(self, hamiltonian, windowed=windowed)
         out.run(mp=mp)
         # finish
         return out

--- a/WrightSim/experiment/_pulse.py
+++ b/WrightSim/experiment/_pulse.py
@@ -113,7 +113,7 @@ class GaussRWA:
             cc = np.ones((eparams.shape[-1]))
         else:
             cc = np.sign(pm)
-        x = np.exp(-1j*(cc[:,None]*(freq[:,None]*(t[None,:] - mu[:,None])+p[:,None])))
+        x = np.exp(-1j*cc[:,None] * (freq[:,None] * (t[None,:] - mu[:,None]) + p[:,None]))
         x*= y[:,None] * np.exp(-(t[None,:] - mu[:,None])**2 / (2*sigma[:,None]**2) )
         return t, x
 

--- a/WrightSim/experiment/_pulse.py
+++ b/WrightSim/experiment/_pulse.py
@@ -113,10 +113,10 @@ class GaussRWA:
             cc = np.ones((eparams.shape[-1]))
         else:
             cc = np.sign(pm)
-        x = np.exp(-1j*cc[:,None] * (freq[:,None] * (t[None,:] - mu[:,None]) + p[:,None]))
+        x = np.exp(-1j * cc[:, None] * (freq[:, None] * (t[None, :] - mu[:, None]) + p[:, None]))
         x*= y[:,None] * np.exp(-(t[None,:] - mu[:,None])**2 / (2*sigma[:,None]**2) )
         return t, x
 
     @classmethod
-    def get_t(cls, d):
+    def get_t(cls, d=None):
         return _get_t(cls, d)

--- a/WrightSim/experiment/_scan.py
+++ b/WrightSim/experiment/_scan.py
@@ -19,9 +19,8 @@ def do_work(arglist):
     t = np.arange(*t_args)
     out = evolve_func(t, efields, iprime, H)
     #if indices[-1] == 0:
-    #   print(indices, pulse_class.timestep, str(iprime) + '              \r',)
+    #   print(indices, '              \r',)
     return indices, out
-
 
 
 # --- class ---------------------------------------------------------------------------------------

--- a/WrightSim/experiment/_scan.py
+++ b/WrightSim/experiment/_scan.py
@@ -222,6 +222,17 @@ class Scan:
         else:
             # figure out the biggest array size we will get
             # now that we know t vals, we can set fixed bounds
+            self.pulse_class.early_buffer = self.early_buffer
+            self.pulse_class.late_buffer = self.late_buffer
+            self.pulse_class.timestep = self.timestep
+
+            d_ind = [i for i in range(len(self.cols)) if self.cols[i] == 'd']
+            t_max = self.efp[..., d_ind].max()
+            t_min = self.efp[..., d_ind].min()
+            self.pulse_class.fixed_bounds_min = t_min - self.early_buffer
+            self.pulse_class.fixed_bounds_max = t_max + self.late_buffer
+            self.pulse_class.fixed_bounds = True
+
             efields_shape[-1] = self.pulse_class.get_t().size
             efields = np.zeros((efields_shape), dtype=np.complex)
             with wt.kit.Timer():

--- a/WrightSim/experiment/_scan.py
+++ b/WrightSim/experiment/_scan.py
@@ -165,7 +165,7 @@ class Scan:
     def get_color(self):
         """Get an array of driven signal frequency for each array point."""
         # in wavenumbers
-        w_axis = self.cols['w']
+        w_axis = [i for i in range(len(self.cols)) if self.cols[i] == 'w'][0]
         wtemp = self.efp[..., w_axis].copy()
         wtemp *= self.pm
         wm = wtemp.sum(axis=-1)

--- a/WrightSim/experiment/_scan.py
+++ b/WrightSim/experiment/_scan.py
@@ -153,7 +153,7 @@ class Scan:
         elif mp:
             from multiprocessing import Pool, cpu_count
             arglist = [[ind, self.iprime, self.t_args, self.ham,
-                        self.pulse_class, self.efp[ind], self.pm, self.timestep,
+                        self.pulse_class, self.efp[ind], self.pm,
                         self.ham.propagator]
                         for ind in np.ndindex(self.array.shape)]
             pool = Pool(processes=cpu_count())

--- a/WrightSim/hamiltonian/TRSF_default.py
+++ b/WrightSim/hamiltonian/TRSF_default.py
@@ -123,10 +123,10 @@ class Hamiltonian:
         mu_ac  = self.mu['a_c']
         mu_bc  = self.mu['b_c']
         
-        out[:,1,0] = 0.5j * mu_Ig * E1 * np.exp(1j*wI*time)
-        out[:,2,0] = 0.5j * mu_Ig * E2 * np.exp(1j*wI*time)
-        out[:,3,0] = 0.5j * mu_ig * E1 * np.exp(1j*wi*time)
-        out[:,4,0] = 0.5j * mu_ig * E2 * np.exp(1j*wi*time)
+        out[:,1,0] = 0.5j * mu_Ig * E1 * np.exp(1j * wI * time)
+        out[:,2,0] = 0.5j * mu_Ig * E2 * np.exp(1j * wI * time)
+        out[:,3,0] = 0.5j * mu_ig * E1 * np.exp(1j * wi * time)
+        out[:,4,0] = 0.5j * mu_ig * E2 * np.exp(1j * wi * time)
         
         out[:,5,1] = 0.5j * mu_2II * E2 * np.exp(1j * wII_I * time)
         out[:,5,2] = 0.5j * mu_2II * E1 * np.exp(1j * wII_I * time)

--- a/WrightSim/hamiltonian/default.py
+++ b/WrightSim/hamiltonian/default.py
@@ -187,7 +187,7 @@ class Hamiltonian:
         outside of the matrix
         """
         # Define transition energies
-        wag  = energies[1]
+        wag  = energies[2]
         w2aa = energies[-1]
         
         # Define dipole moments
@@ -195,12 +195,12 @@ class Hamiltonian:
         mu_2aa = self.mu[-1]
     
         # Define helpful variables
-        A_1 = 0.5j * mu_ag * E1 * np.exp(-1j * wag * time)
-        A_2 = 0.5j * mu_ag * E2 * np.exp(1j * wag * time)
-        A_2prime = 0.5j * mu_ag * E3 * np.exp(-1j * wag * time)
-        B_1 = 0.5j * mu_2aa * E1 * np.exp(-1j * w2aa * time)
-        B_2 = 0.5j * mu_2aa * E2 * np.exp(1j * w2aa * time)
-        B_2prime = 0.5j * mu_2aa * E3 * np.exp(-1j * w2aa * time)
+        A_1 = 0.5j * mu_ag * E1 * np.exp(1j * wag * time)
+        A_2 = 0.5j * mu_ag * E2 * np.exp(-1j * wag * time)
+        A_2prime = 0.5j * mu_ag * E3 * np.exp(1j * wag * time)
+        B_1 = 0.5j * mu_2aa * E1 * np.exp(1j * w2aa * time)
+        B_2 = 0.5j * mu_2aa * E2 * np.exp(-1j * w2aa * time)
+        B_2prime = 0.5j * mu_2aa * E3 * np.exp(1j * w2aa * time)
 
         # Initailze the full array of all hamiltonians to zero
         out = np.zeros((len(time), len(energies), len(energies)), dtype=np.complex128)

--- a/WrightSim/mixed/propagate.py
+++ b/WrightSim/mixed/propagate.py
@@ -44,13 +44,13 @@ def runge_kutta(t, efields, n_recorded, hamiltonian):
         # storing these values
         if k >= len(t) - n_recorded:
             for rec,native in enumerate(hamiltonian.recorded_indices):
-                rho_emitted[rec, emitted_index] = rho_i[native] * np.exp(1j * ws[rec] * t[k])
+                rho_emitted[rec, emitted_index] = rho_i[native] * np.exp(-1j * ws[rec] * t[k])
             emitted_index += 1
     # Last timestep
     temp_delta_rho = np.dot(H[-1], rho_i)
     rho_i += temp_delta_rho*dt
     for rec,native in enumerate(hamiltonian.recorded_indices):
-        rho_emitted[rec, emitted_index] = rho_i[native] * np.exp(1j * ws[rec] * t[-1])
+        rho_emitted[rec, emitted_index] = rho_i[native] * np.exp(-1j * ws[rec] * t[-1])
 
     return rho_emitted
 

--- a/WrightSim/mixed/propagate.py
+++ b/WrightSim/mixed/propagate.py
@@ -32,6 +32,7 @@ def runge_kutta(t, efields, n_recorded, hamiltonian):
     # index to keep track of elements of rho_emitted
     emitted_index = 0
     rho_i = hamiltonian.rho.copy()
+    ws = hamiltonian.omega[hamiltonian.recorded_indices]
     for k in range(len(t)-1):
         # calculate delta rho based on previous rho values
         temp_delta_rho = np.dot(H[k], rho_i)
@@ -43,13 +44,13 @@ def runge_kutta(t, efields, n_recorded, hamiltonian):
         # storing these values
         if k >= len(t) - n_recorded:
             for rec,native in enumerate(hamiltonian.recorded_indices):
-                rho_emitted[rec, emitted_index] = rho_i[native]
+                rho_emitted[rec, emitted_index] = rho_i[native] * np.exp(1j * ws[rec] * t[k])
             emitted_index += 1
     # Last timestep
     temp_delta_rho = np.dot(H[-1], rho_i)
     rho_i += temp_delta_rho*dt
     for rec,native in enumerate(hamiltonian.recorded_indices):
-        rho_emitted[rec, emitted_index] = rho_i[native]
+        rho_emitted[rec, emitted_index] = rho_i[native] * np.exp(1j * ws[rec] * t[-1])
 
     return rho_emitted
 

--- a/scripts/target.py
+++ b/scripts/target.py
@@ -27,48 +27,51 @@ here = os.path.abspath(os.path.dirname(__file__))
 dt = 50.  # pulse duration (fs)
 slitwidth = 120.  # mono resolution (wn)
 
-nw = 256  # number of frequency points (w1 and w2)
-nt = 256  # number of delay points (d2)
+nw = 51  # number of frequency points (w1 and w2)
+nt = 51  # number of delay points (d2)
 
 
 # --- workspace -----------------------------------------------------------------------------------
 
+w_central = 1650.
+coupling = 0.
+tau = 50.
 
 # create experiment
 exp = ws.experiment.builtin('trive')
-exp.w1.points = np.linspace(-2.5, 2.5, nw) * 4 * np.log(2) / dt * 1 / (2 * np.pi * 3e-5)
-exp.w2.points = np.linspace(-2.5, 2.5, nw) * 4 * np.log(2) / dt * 1 / (2 * np.pi * 3e-5)
+exp.w1.points = np.linspace(-2.5, 2.5, nw + 5) * 4 * np.log(2) / dt * 1 / (2 * np.pi * 3e-5) + w_central
+exp.w2.points = np.linspace(-2.5, 2.5, nw) * 4 * np.log(2) / dt * 1 / (2 * np.pi * 3e-5) + w_central
 #exp.w2.points = 0.
 exp.d2.points = np.linspace(-2 * dt, 8 * dt, nt)
 exp.w1.active = exp.w2.active = exp.d2.active = True
-exp.d2.points = 4 * dt
+exp.d2.points = 0 * dt
 exp.d2.active = False
 exp.timestep = 2.
-exp.early_buffer = 100.0
-exp.late_buffer  = 400.0
+exp.early_buffer = 2 * dt
+exp.late_buffer  = 6 * tau
 
 # create hamiltonian
-ham = ws.hamiltonian.Hamiltonian(w_central=300.)
-#ham.time_orderings = [5]
-ham.recorded_elements = [7,8]
+ham = ws.hamiltonian.Hamiltonian(w_central=w_central, coupling=coupling, tau=tau)
+# ham.time_orderings = [6]
+ham.recorded_indices = [7,8]
 
 # do scan
 begin = time.perf_counter()
-scan = exp.run(ham, mp='cpu')
+scan = exp.run(ham, mp=False)  # 'cpu')
 print(time.perf_counter()-begin)
-gpuSig = scan.sig.copy()
-#with wt.kit.Timer():
+# gpuSig = scan.sig.copy()
+ #with wt.kit.Timer():
 #    scan2 = exp.run(ham, mp=None)
-#cpuSig = scan2.sig.copy()
+# cpuSig = scan2.sig.copy()
 plt.close('all')
 # measure and plot
 fig, gs = wt.artists.create_figure(cols=[1, 'cbar'])
 ax = plt.subplot(gs[0, 0])
 xi = exp.active_axes[0].points
 yi = exp.active_axes[1].points
-zi = np.sum(np.abs(np.sum(scan.sig, axis=-2)), axis=-1).T
-#zi /= zi.max()
-ax.pcolor(xi, yi, zi,cmap='default')# vmin=0, vmax=1, cmap='default')
+zi = np.abs(scan.sig.sum(axis=-2)).sum(axis=-1).T
+# zi /= zi.max()
+ax.pcolor(xi, yi, zi, cmap='default')
 ax.contour(xi, yi, zi, colors='k')
 # decoration
 ax.set_xlabel(exp.active_axes[0].name)

--- a/scripts/target_TRSF.py
+++ b/scripts/target_TRSF.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 """
-creates an (wIR, w4) "movie" scan
+creates an (wIR, w4) scan
 """
 
 
@@ -22,13 +22,10 @@ import WrightSim as ws
 here = os.path.abspath(os.path.dirname(__file__))
 wn_to_omega = 2*np.pi*3*10**-5
 
-
 dt = 1e3  # pulse duration (fs)
 slitwidth = 120.  # mono resolution (wn)
 
-nw = 21  # number of frequency points (w1 and w2)
-#nt = 16  # number of delay points (d2)
-
+nw = 16  # number of frequency points (w1 and w2)
 
 # --- workspace -----------------------------------------------------------------------------------
 
@@ -49,29 +46,27 @@ exp.late_buffer = 1.5e3
 ham = ws.hamiltonian.Hamiltonian_TRSF()
 
 # do scan
-scan = exp.run(ham, mp=False)
+if __name__ == '__main__':
+    scan = exp.run(ham, mp='cpu')
 
-#"""
-plt.close('all')
-# measure and plot
-fig, gs = wt.artists.create_figure(cols=[1, 'cbar'])
-ax = plt.subplot(gs[0, 0])
-xi = exp.active_axes[0].points
-yi = exp.active_axes[2].points
-for rec, native in enumerate(ham.recorded_indices):
-    w = ham.omega[native] * wn_to_omega
-    time = np.arange(scan.sig.shape[-1]) * exp.timestep
-    scan.sig[..., rec, :] *= np.exp(-1j * w * time)
-zi = np.sum(np.abs(np.sum(scan.sig, axis=-2)), axis=-1)
-zi = zi.diagonal(axis1=0, axis2=1).copy()
-zi /= np.nanmax(zi)
-ax.contourf(xi, yi, zi, vmin=0, vmax=1, cmap='default')
-ax.contour(xi, yi, zi, colors='k')
-# decoration
-ax.set_xlabel(exp.active_axes[0].name)
-ax.set_ylabel(exp.active_axes[2].name)
-cax = plt.subplot(gs[0, 1])
-wt.artists.plot_colorbar(label='ampiltude')
-# finish
-plt.show()
-#"""
+    #"""
+    plt.close('all')
+    # measure and plot
+    fig, gs = wt.artists.create_figure(cols=[1, 'cbar'])
+    ax = plt.subplot(gs[0, 0])
+    xi = exp.active_axes[0].points
+    yi = exp.active_axes[2].points
+    
+    zi = np.sum(np.abs(np.sum(scan.sig, axis=-2)), axis=-1)
+    zi = zi.diagonal(axis1=0, axis2=1).copy()
+    zi /= np.nanmax(zi)
+    ax.pcolormesh(xi, yi, zi, vmin=0, vmax=1, cmap='default')
+    ax.contour(xi, yi, zi, colors='k')
+    # decoration
+    ax.set_xlabel(exp.active_axes[0].name)
+    ax.set_ylabel(exp.active_axes[2].name)
+    cax = plt.subplot(gs[0, 1])
+    wt.artists.plot_colorbar(label='ampiltude')
+    # finish
+    plt.show()
+    #"""

--- a/scripts/test_default_phase_delay_dependence.py
+++ b/scripts/test_default_phase_delay_dependence.py
@@ -1,0 +1,81 @@
+import WrightSim as ws
+import WrightTools as wt
+import numpy as np
+import matplotlib.pyplot as plt
+
+dt = 50
+nt = 21
+wn_to_omega = 2 * np.pi * 3e-5  # cm / s
+w_central = 3000
+coupling = 0
+
+ham = ws.hamiltonian.Hamiltonian(
+    w_central=w_central * wn_to_omega,
+    coupling=coupling * wn_to_omega,
+)
+ham.recorded_elements = [7, 8]
+
+exp = ws.experiment.builtin('trive')
+exp.w1.points = w_central  # wn
+exp.w2.points = w_central  # wn
+exp.d2.points = np.linspace(-10, 10, nt)  # fs
+exp.d1.points = np.linspace(-10, 10, nt)
+exp.s1.points = exp.s2.points = dt  # fs
+
+exp.d1.active = exp.d2.active = True
+
+exp.timestep = 1
+exp.early_buffer = 100.
+exp.late_buffer = 300.
+
+scan = exp.run(ham, mp=False, windowed=True)
+
+# plot amplitude
+if False:
+    zi = np.sum(np.abs(np.sum(scan.sig, axis=-2)), axis=-1)
+    yi = exp.d1.points
+    xi = exp.d2.points
+    
+    fig, gs = wt.artists.create_figure(cols=[1])
+    ax0 = plt.subplot(gs[0])
+    ax0.pcolormesh(xi, yi, zi, cmap='default')
+    plt.grid(b=True)
+    plt.xlabel(exp.d2.name)
+    plt.ylabel(exp.d1.name)
+    plt.show()
+
+efields = scan.efields()
+sig = scan.sig.sum(axis=-2)
+driven_sig = 1j * efields.prod(axis=-2)
+
+# look at the phase fringes ddue to interference with each pulse
+
+# E1 interference (first column) should modulate along y-axis
+# E2 interference (second column) should modulate along diagonal
+# E2p interference (third column) should modulate along x-axis
+
+# simulated and driven experiments (top and bottom rows, resp.) 
+# should have the same phase of fringes
+
+plt.close('all')
+fig, gs = wt.artists.create_figure(width='single', nrows=2, cols=[1, 1, 1])
+for i in range(scan.npulses):
+    lo = efields[..., i, :]
+    if scan.pm[i] == 1:
+        lo = lo.conjugate()
+    diff = (lo * sig).imag.sum(axis=-1)
+    driven_diff = (lo * driven_sig).imag.sum(axis=-1)
+
+    axi = plt.subplot(gs[i])
+    axi.pcolormesh(exp.d2.points, exp.d1.points, -diff, 
+                   vmin=-np.abs(diff).max(),
+                   vmax=np.abs(diff).max(),
+                   cmap=wt.artists.colormaps['signed'])
+    plt.grid(b=True)
+    axi2 = plt.subplot(gs[i+3])
+    axi2.pcolormesh(exp.d2.points, exp.d1.points, driven_diff,
+                    vmin=-np.abs(driven_diff).max(),
+                    vmax=np.abs(driven_diff).max(),
+                    cmap=wt.artists.colormaps['signed'])
+    plt.grid(b=True)
+

--- a/scripts/test_default_phase_delay_dependence.py
+++ b/scripts/test_default_phase_delay_dependence.py
@@ -79,3 +79,4 @@ for i in range(scan.npulses):
                     cmap=wt.artists.colormaps['signed'])
     plt.grid(b=True)
 
+plt.show()


### PR DESCRIPTION
- [x] fix resonance conditions of `default` hamiltonian (previously untested because all system frequencies were set to zero).
- [x] move time axis determination outside of `pulse_class` and into scan object.
- [x] in `mixed`, send output to the same rotating frame (namely, the lab frame where DC output means zero frequency)
- [x] validate correct phase output properties (put in scripts folder)
- [x] package a script for investigating the phase behavior of scan signal (put in `scripts` folder)
- [x] tweak target scripts so that they still work