### PR TITLE
is Axis bool into INIs

### DIFF
--- a/WrightSim/experiment/__init__.py
+++ b/WrightSim/experiment/__init__.py
@@ -34,13 +34,15 @@ def from_ini(p):
     axis_names.remove('main')
     axes = []
     for name in axis_names:
-        points = ini.read(name, 'points')
-        active = ini.read(name, 'active')
-        pulses = ini.read(name, 'pulses')
-        parameter = ini.read(name, 'parameter')
-        axis = Axis(points=points, units=None, name=name, active=active, pulses=pulses,
+        is_axis = ini.read(name, 'axis')
+        if is_axis: 
+            points = ini.read(name, 'points')
+            active = ini.read(name, 'active')
+            pulses = ini.read(name, 'pulses')
+            parameter = ini.read(name, 'parameter')
+            axis = Axis(points=points, units=None, name=name, active=active, pulses=pulses,
                     parameter=parameter, cols=pulse_class.cols)
-        axes.append(axis)
+            axes.append(axis)
     # construct experiment object
     name = ini.read('main', 'name')
     pm = ini.read('main', 'pm')

--- a/WrightSim/experiment/trive.ini
+++ b/WrightSim/experiment/trive.ini
@@ -4,66 +4,77 @@ pm = [1, -1, 1]
 pulse class name = 'GaussRWA'
 
 [w1]
+axis = True
 active = False
 pulses = [0]
 parameter = 'w'
 points = 7000.0
 
 [w2]
+axis = True
 active = False
 pulses = [1, 2]
 parameter = 'w'
 points = 7000.0
 
 [d1]
+axis = True
 active = False
 pulses = [2]
 parameter = 'd'
 points = 0.0
 
 [d2]
+axis = True
 active = False
 pulses = [0]
 parameter = 'd'
 points = 0.0
 
 [A1]
+axis = True
 active = False
 pulses = [0]
 parameter = 'A'
 points = 1.0
 
 [A2]
+axis = True
 active = False
 pulses = [1, 2]
 parameter = 'A'
 points = 1.0
 
 [p1]
+axis = True
 active = False
 pulses = [0]
 parameter = 'p'
 points = 0.0
 
 [p2]
+axis = True
 active = False
 pulses = [1]
 parameter = 'p'
 points = 0.0
 
 [p3]
+axis = True
 active = False
 pulses = [2]
 parameter = 'p'
 points = 0.0
 
 [s1]
+axis = True
 active = False
 pulses = [0]
 parameter = 's'
 points = 50.
 
 [s2]
+axis = True
 active = False
 pulses = [1, 2]
 parameter = 's'

--- a/WrightSim/experiment/trsf.ini
+++ b/WrightSim/experiment/trsf.ini
@@ -4,85 +4,103 @@ pm = [1, 1, 1]
 pulse class name = 'GaussRWA'
 
 [w1]
+axis = True
 active = False
 pulses = [0]
 parameter = 'w'
 points = 1500.0
 
 [w2]
+axis = True
 active = False
 pulses = [1]
 parameter = 'w'
 points = 1500.0
 
 [w3]
+axis = True
 active = False
 pulses = [2]
 parameter = 'w'
 points = 19000.0
 
 [d1]
+axis = True
 active = False
 pulses = [0]
 parameter = 'd'
 points = 0.0
 
 [d2]
+axis = True
 active = False
 pulses = [1]
 parameter = 'd'
 points = 0.0
 
 [A1]
+axis = True
 active = False
 pulses = [0]
 parameter = 'A'
 points = 1.0
 
 [A2]
+axis = True
 active = False
 pulses = [1]
 parameter = 'A'
 points = 1.0
 
 [A3]
+axis = True
 active = False
 pulses = [2]
 parameter = 'A'
 points = 1.0
 
 [p1]
+axis = True
 active = False
 pulses = [0]
 parameter = 'p'
 points = 0.0
 
 [p2]
+axis = True
 active = False
 pulses = [1]
 parameter = 'p'
 points = 0.0
 
 [p3]
+axis = True
 active = False
 pulses = [2]
 parameter = 'p'
 points = 0.0
 
 [s1]
+axis = True
 active = False
 pulses = [0]
 parameter = 's'
 points = 1000.
 
 [s2]
+axis = True
 active = False
 pulses = [1]
 parameter = 's'
 points = 1000.
 
 [s3]
+axis = True
 active = False
 pulses = [2]
 parameter = 's'
 points = 1000.
+
+[theta31]
+axis = False
+active = False


### PR DESCRIPTION
Placed extra conditional into the experiment load.   It allows for certain parameters of an experiment not to be incorporated as axes in a WrightSim Hamiltonian.   These parameters currently do not install into the Experiment class in any form....scripts that run the simulations can load these other parameters via wt.kit or any other ini reading.  An install of these "axis-less" parameters into the class can be done in a later update to the code.

This option was meant to self-contain the experiment parameters in the INI and allow the script to read the other parameters so as to apply a sinc^2 factor or other coefficient outside the run of the simulation.   Sinc^2 factors do not have to be applied during the Hamiltonian propagation for 1st order simulations, for example.